### PR TITLE
Fix the link to the Expense Manager demo PWA

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -244,7 +244,7 @@
 		</a>
 
 		<a class="list__item app js-app"
-				href="https://demo.vaadin.com/expense-manager/"
+				href="https://expensemanager.demo.vaadin.com/"
 				data-app="expense-manager"
 				data-tags="demo tool">
 			<div class="app__wrapper">


### PR DESCRIPTION
This year we have changed the link for the Expense Manager demo application and deployed new version using the latest Vaadin components. We do not yet have redirect (to be added later), so changing the link to the correct one here manually for now.